### PR TITLE
In donation completion modal, shows studies from other services that a participant can donate

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -18,6 +18,17 @@ class Vertical(BaseModel):
     name = models.CharField(max_length=24, choices=VerticalName)
 
 
+class ServiceManager(models.Manager):
+    def unique_service_names(self, max_count=4, excluded_names=set()):
+        return set(
+            [
+                service.name
+                for service in self.all()
+                if service.name not in excluded_names
+            ][:max_count]
+        )
+
+
 class Service(BaseModel):
     class ServiceName(models.TextChoices):
         TUMBLR = 'tumblr'
@@ -25,6 +36,8 @@ class Service(BaseModel):
 
     name = models.CharField(max_length=240, choices=ServiceName)
     verticals = models.ManyToManyField(Vertical)
+
+    objects = ServiceManager()
 
     def __str__(self):
         verticals = ', '.join([vertical.name for vertical in self.verticals.all()])

--- a/core/static/site.css
+++ b/core/static/site.css
@@ -173,6 +173,25 @@ a.button {
   gap: 15px;
 }
 
+.donation-modal hr {
+  height: 1px;
+  background-color: #bcbcbc;
+  width: 100%;
+  border: none;
+  margin: 0;
+}
+
+.donation-modal--other-services-list--item {
+  display: flex;
+  align-items: center;
+  max-width: 30%;
+  justify-content: space-between;
+}
+
+.donation-modal--other-services-list--item p {
+  margin: 8px 0;
+}
+
 /* Study page and fragments */
 .service-list {
   display: grid;

--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -22,10 +22,18 @@ Pardner Demo Site
             class="homepage--studies-list-header-dropdown"
             name="filtered_service_name"
           >
-            <option value="" selected="selected">All</option>
+            <option
+              value=""
+              {% if not default_service_name %}selected="selected"{% endif %}
+            >All</option>
             <hr />
             {% for service_name in service_names %}
-              <option value="{{ service_name }}">{{ service_name | title }}</option>
+              <option
+                value="{{ service_name }}"
+                {% if default_service_name and default_service_name == service_name %}
+                  selected="selected"
+                {% endif %}
+              >{{ service_name | title }}</option>
             {% endfor %}
           </select>
         </form>

--- a/core/templates/core/study/donation_complete_modal.html
+++ b/core/templates/core/study/donation_complete_modal.html
@@ -2,7 +2,7 @@
 <div class="donation-modal js-modal-page">
   <h1>Thank you!</h1>
   <p>
-    You have successfully donated your {{ service_name | title }} data to {{ study.name }}.
+    You have successfully donated your {{ service_donated_name | title }} data to {{ study.name }}.
     {% if num_services_remaining == 0 %}
       You've donated all the data you can for this study!
     {% elif num_services_remaining > 0 %}
@@ -10,6 +10,21 @@
     {% endif %}
     We appreciate your contribution!
   </p>
+  {% if service_names %}
+    <hr />
+    <p><strong>Consider donating data from other platforms! Here are studies seeking data from:</strong></p>
+    <div class="donation-modal--other-services-list">
+      {% for service_name in service_names %}
+        <div class="donation-modal--other-services-list--item">
+          <p><strong>{{ service_name | title }}</strong></p>
+          <a
+            href="{% url 'index_with_default' default_service_name=service_name %}"
+            title="See studies seeking {{ service_name | title }} data"
+          >Learn more</a>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
   <div class="modal__footer">
       <button class="button button--primary js-close-modal">Close</button>
   </div>

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,15 +3,28 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("", views.index, name="index"),
-    path('study_list_items', views.study_list_items, name='study_list_items'),
-    path("study/<int:study_id>/", views.study_detail, name="study_detail"),
-    path("study/<int:study_id>/donation-modal/<int:service_id>", views.study_donation_modal, name="study_donation_modal"),
-    path("study/<int:study_id>/donation-complete-modal", views.study_donation_complete_modal, name="study_donation_complete_modal"),
+    path('', views.index, name='index'),
     path(
-        "study/<int:study_id>/connect/<int:service_id>",
-        views.study_connect,
-        name="study_connect"
+        'index_with_default/<default_service_name>',
+        views.index_with_default,
+        name='index_with_default',
     ),
-    path("callback/<transfer_service_name>", views.callback, name="callback")
+    path('study_list_items', views.study_list_items, name='study_list_items'),
+    path('study/<int:study_id>/', views.study_detail, name='study_detail'),
+    path(
+        'study/<int:study_id>/donation-modal/<int:service_id>',
+        views.study_donation_modal,
+        name='study_donation_modal',
+    ),
+    path(
+        'study/<int:study_id>/donation-complete-modal',
+        views.study_donation_complete_modal,
+        name='study_donation_complete_modal',
+    ),
+    path(
+        'study/<int:study_id>/connect/<int:service_id>',
+        views.study_connect,
+        name='study_connect',
+    ),
+    path('callback/<transfer_service_name>', views.callback, name='callback'),
 ]


### PR DESCRIPTION
Closes #33 

Implemented using a "dummy" view (`index_with_default`) that just redirects to the main view (`index`) with the default service name retrieved from the session. I did this to avoid changing the URL so that it included a parameter for the default service name since that would be made obsolete as soon as another service was picked from the select element.

### Screenshots/videos
**Single platform**
<img width="934" height="333" alt="Screenshot 2025-09-02 at 2 13 05 PM" src="https://github.com/user-attachments/assets/df0c79ed-c110-43eb-89b4-69f4009b14f6" />

**Two platforms**
<img width="873" height="351" alt="Screenshot 2025-09-02 at 3 30 23 PM 1" src="https://github.com/user-attachments/assets/abca40aa-2e13-429f-a53d-029791375d5c" />

**Video flow**

https://github.com/user-attachments/assets/e8c4384c-0108-492b-a730-9ffa9946677a

