### PR TITLE
Makes donation buttons clickable in home page again

### DIFF
--- a/core/static/site.js
+++ b/core/static/site.js
@@ -57,7 +57,7 @@
     );
     modalTriggers.forEach((triggerEl) => {
       const modalUrl = triggerEl.getAttribute(MODAL_TRIGGER_ATTRIBUTE_NAME);
-      triggerEl.addEventListener("click", () => {
+      triggerEl.addEventListener('click', () => {
         triggerModal(modalUrl);
       });
     });
@@ -70,7 +70,7 @@
   // rendered after DOMContentLoaded gets fired.
   const observer = new MutationObserver((mutationList, observer) => {
     mutationList.forEach((mutation) => {
-      if (mutation.type === "childList") {
+      if (mutation.type === 'childList') {
         addModalTriggers();
       }
     });


### PR DESCRIPTION
Closes #37 

**Bug description**
In #36 I described how I was intercepting the request that got sent when the select button value was modified (i.e., a service was selected to filter studies by) to decide which studies to render. When I did this, by necessity, I loaded the DOM in two waves: the first one for everything but the studies, and the second one just for the studies. However, the code that attached the modal opening to the "Donate Data" buttons still only occurred once: when the DOM initially loaded. Since all the "Donate Data" buttons loaded *after* that, none of them got the modal triggers attached to them.

**Fix**
I added a [mutation observer](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to `study-list` (the parent `div` of the study blocks) and listened from any changes to its child elements. Once a change occurs, it triggers the function that attaches the modal triggers to the buttons once again.

Note that we still need the original modal trigger attaching when DOMContentLoaded is fired for the case where the page being loaded is a single-study page.

I also standardized some of the Javascipt, so I'd turn on "Ignore Whitespace"

https://github.com/user-attachments/assets/e7bca3c6-495f-49ff-9cc1-07b6f3630b9a