### PR TITLE
Adapt Tumblr donation flow to typed library return and add pytest suite

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,7 +6,8 @@
 #
 ## Workflow Jobs
 #
-# 1) deploy - Deploy to Cloud Run Staging
+# 1) test   - Run pytest suite (must pass before deploy)
+# 2) deploy - Deploy to Cloud Run Staging
 #
 ## Deployment Flow
 #
@@ -51,8 +52,41 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Run tests before deploying
+  test:
+    runs-on: ubuntu-latest
+    env:
+      DJANGO_SETTINGS_MODULE: pardnersite.settings
+
+    steps:
+      - name: Checkout pardner-site repository
+        uses: actions/checkout@v4
+
+      - name: Checkout pardner library
+        uses: actions/checkout@v4
+        with:
+          repository: dtinit/pardner
+          path: pardner-lib
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pardner library
+        run: pip install ./pardner-lib
+
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest core/tests.py -v
+
   # Deploy to Google Cloud Run
   deploy:
+    needs: test
     runs-on: ubuntu-latest
     environment:
       name: Staging

--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,7 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/
 
 # Ruff stuff:
 .ruff_cache/

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    # Automatically adds django_db marker to all test functions
+    for item in items:
+        item.add_marker(pytest.mark.django_db)

--- a/core/internal/utils.py
+++ b/core/internal/utils.py
@@ -66,7 +66,7 @@ def fetch_and_store_data(transfer_service_manager, service_account, service_name
     try:
         match service_name.lower():
             case Service.ServiceName.TUMBLR:
-                posts = transfer_service_manager.fetch_social_posting_vertical(
+                _, raw_posts = transfer_service_manager.fetch_social_posting_vertical(
                     text_only=False
                 )
                 DonatedPost.objects.bulk_create([
@@ -76,7 +76,7 @@ def fetch_and_store_data(transfer_service_manager, service_account, service_name
                         service_post_id=str(post.get('id', '')),
                         raw_data=post,
                     )
-                    for post in posts
+                    for post in raw_posts
                 ])
     except Exception as e:
         logger.exception(

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,3 +1,112 @@
-from django.test import TestCase
+import pytest
+from unittest.mock import MagicMock
 
-# Create your tests here.
+from pardner.exceptions import TumblrAPIError
+
+from core.internal.utils import fetch_and_store_data
+from core.models import DonatedPost, Service, ServiceAccount, Study
+
+
+@pytest.fixture
+def tumblr_service_account():
+    """Creates a minimal Study + Service + ServiceAccount for Tumblr tests."""
+    service = Service.objects.create(name=Service.ServiceName.TUMBLR)
+    study = Study.objects.create(name='Test Study', authors='Tester')
+    study.services.add(service)
+    service_account = ServiceAccount.objects.create(
+        study=study,
+        service=service,
+        state='test-state',
+    )
+    return study, service_account
+
+
+
+def test_fetch_and_store_data_tumblr_success(tumblr_service_account):
+    """
+    When fetch_social_posting_vertical returns a valid tuple, DonatedPost
+    records are created from the raw_posts list (the second element).
+    """
+    _, service_account = tumblr_service_account
+    raw_post = {'id': 42, 'summary': 'hello'}
+
+    mock_service = MagicMock()
+    mock_service.fetch_social_posting_vertical.return_value = ([], [raw_post])
+
+    fetch_and_store_data(mock_service, service_account, 'tumblr')
+
+    posts = DonatedPost.objects.filter(service_account=service_account)
+    assert posts.count() == 1
+    assert posts.first().service_post_id == '42'
+    assert posts.first().raw_data == raw_post
+
+
+def test_fetch_and_store_data_tumblr_api_error_does_not_propagate(
+    tumblr_service_account,
+):
+    """
+    When fetch_social_posting_vertical raises TumblrAPIError, the exception is
+    caught inside fetch_and_store_data and no DonatedPost records are created.
+    The donation flow is unaffected (best-effort semantics).
+    """
+    _, service_account = tumblr_service_account
+
+    mock_service = MagicMock()
+    mock_service.fetch_social_posting_vertical.side_effect = TumblrAPIError(
+        'Tumblr is down'
+    )
+
+    fetch_and_store_data(mock_service, service_account, 'tumblr')  # should not raise
+
+    assert DonatedPost.objects.filter(service_account=service_account).count() == 0
+
+
+def test_callback_stores_token_and_redirects(client, mocker, tumblr_service_account):
+    """
+    A successful callback stores the access token on the ServiceAccount and
+    redirects to the study detail page.
+    """
+    study, service_account = tumblr_service_account
+
+    mock_manager = MagicMock()
+    mock_manager.fetch_token.return_value = {'access_token': 'test-token-123'}
+    mocker.patch('core.views.get_transfer_service', return_value=mock_manager)
+    mocker.patch('core.views.fetch_and_store_data')
+
+    response = client.get(
+        '/callback/tumblr',
+        {'state': 'test-state', 'code': 'auth-code'},
+    )
+
+    service_account.refresh_from_db()
+    assert service_account.access_token == 'test-token-123'
+    assert response.status_code == 302
+    assert response['Location'] == f'/study/{study.id}/'
+
+
+def test_callback_data_fetch_failure_still_completes_donation(
+    client, mocker, tumblr_service_account
+):
+    """
+    When Tumblr's API raises TumblrAPIError, fetch_and_store_data catches it
+    internally and does not propagate. The token is already stored before the
+    data fetch, so the callback still redirects and the donation is complete.
+    """
+    study, service_account = tumblr_service_account
+
+    mock_manager = MagicMock()
+    mock_manager.fetch_token.return_value = {'access_token': 'test-token-456'}
+    mock_manager.fetch_social_posting_vertical.side_effect = TumblrAPIError(
+        'Tumblr is down'
+    )
+    mocker.patch('core.views.get_transfer_service', return_value=mock_manager)
+
+    response = client.get(
+        '/callback/tumblr',
+        {'state': 'test-state', 'code': 'auth-code'},
+    )
+
+    service_account.refresh_from_db()
+    assert service_account.access_token == 'test-token-456'
+    assert response.status_code == 302
+    assert response['Location'] == f'/study/{study.id}/'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = pardnersite.settings
+python_files = tests.py test_*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ django-environ==0.12.0
 gunicorn==23.0.0
 whitenoise==6.8.2
 psycopg2-binary==2.9.10
+pytest>=8.4.1
+pytest-django>=4.11.0
+pytest-mock>=3.14.1


### PR DESCRIPTION
Depends on the pardner library Tumblr hardening PR #83.

The pardner library changed how `fetch_social_posting_vertical` returns data (now a tuple instead of a plain list), so the site needs a small update. Also took the opportunity to add the site's first test suite and hook it into CI so we stop deploying blind.


- In **`utils.py`** we now unpack the new tuple (`_, raw_posts = ...`). The site still stores raw JSON in `DonatedPost`, so the parsed verticals are discarded for now. Everything else in the donation flow stays the same — if fetching fails, it's logged and the donation still completes since the token is already saved.

- Added `pytest`, `pytest-django`, and `pytest-mock`. Created `pytest.ini` and `conftest.py` so tests work with Django. Follows the same style as the pardner library tests.

- Added a `test` job in `ci-cd.yml` that runs before deploy. If tests fail, deployment is blocked.